### PR TITLE
Fixed exception if no account history is available

### DIFF
--- a/src/main/java/uk/oczadly/karl/jnano/rpc/response/ResponseAccountHistory.java
+++ b/src/main/java/uk/oczadly/karl/jnano/rpc/response/ResponseAccountHistory.java
@@ -147,8 +147,14 @@ public class ResponseAccountHistory extends RpcResponse {
         public ResponseAccountHistory deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
             JsonObject jsonObj = json.getAsJsonObject();
-            JsonArray historyJson = jsonObj.getAsJsonArray("history");
-    
+            JsonArray historyJson;
+			//use try-catch to allow for history being empty
+			try {
+				historyJson = jsonObj.getAsJsonArray("history");
+			} catch (ClassCastException e) {
+				historyJson = new JsonArray();
+			}
+
             // Deserialize response
             ResponseAccountHistory response = new ResponseAccountHistory(
                     context.deserialize(jsonObj.get("account"), NanoAccount.class),


### PR DESCRIPTION
This pull request is to fix a problem I encountered using the `RequestAccountHistory` RPC request. When the account had no account history, the nano node I was running locally returned an empty string in the `history` field.

Whether this was a problem with my nano node or this library I am unsure, however I was running the official nano docker node `nanocurrency/nano:V22.0` (node version 22), and therefore believe this fix may be useful to add to the project as it does not break any existing functionality.

The error previously thrown by Gson was a `ClassCastException` when trying to get the `history` attribute as a `JsonArray` as the type of the attribute was identified as `JsonPrimitive` due to it being an empty string. My solution was just surrounding the internal response parsing in a try-catch and using an empty `JsonArray` if the `ClassCastException` was thrown.

It'd be understandable to reject this pull request as it could just be an issue with the nano docker node, also a developer could catch the `RPCException` externally and assume this means that there was no history for the account. However, I believe this fix would be useful to other developers who encounter this issue as I expect the nano docker node is frequently used by developers who may not be aware of this strange behavior.