### PR TITLE
Fixed 'timestamp' field clash

### DIFF
--- a/src/main/java/uk/oczadly/karl/jnano/rpc/response/RpcResponse.java
+++ b/src/main/java/uk/oczadly/karl/jnano/rpc/response/RpcResponse.java
@@ -25,7 +25,7 @@ import java.time.Instant;
  */
 public abstract class RpcResponse {
     
-    private final Instant timestamp = Instant.now();
+    private transient final Instant timestamp = Instant.now();
     private volatile JsonObject rawJson;
     
     


### PR DESCRIPTION
Previously broke de-serialization of ResponseTelemetry.java as Gson recognised there were two fields with the name 'timestamp'. I have checked and I believe ResponseTelemetry was the only class affected by this. This pull request should not break any existing functionality and will allow ResponseTelemetry.java to be successfully de-serialized by Gson.